### PR TITLE
Dwl/feature/support php 8.1 symfony5 and 6

### DIFF
--- a/Exceptions/QueryParameterMismatchException.php
+++ b/Exceptions/QueryParameterMismatchException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Circle\DoctrineRestDriver\Exceptions;
+
+class QueryParameterMismatchException extends DoctrineRestDriverException
+{
+    /**
+     * @param $query
+     * @param $needle
+     */
+    public function __construct($query, $needle)
+    {
+        parent::__construct("Either the provided query is invalid or there are more parameters than {$needle}-placeholders in:\n{$query}");
+    }
+}

--- a/MetaData.php
+++ b/MetaData.php
@@ -18,7 +18,7 @@
 
 namespace Circle\DoctrineRestDriver;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManager;
 
 /**
  * Provider for doctrine meta data
@@ -29,7 +29,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 class MetaData {
 
     /**
-     * @var ObjectManager
+     * @var EntityManager
      */
     private $em;
 
@@ -38,7 +38,7 @@ class MetaData {
      */
     public function __construct() {
         $this->em = array_filter(debug_backtrace(), function($trace) {
-            return isset($trace['object']) && $trace['object'] instanceof ObjectManager;
+            return isset($trace['object']) && $trace['object'] instanceof EntityManager;
         });
     }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Motivation
+
 What does a black sheep and a white sheep have in common? They produce wool.<br />
-What does a big bus and a small bus have in common? They drive people around.<br />
-And what does a SQL database and a REST API have in common? They store data.<br />
+What does a big bus and a small bus have in common? They drive people ardoes a SQL database and a REST API have in common? They store data.<br />
 
 As blatantly obvious as this sounds the consequences are tremendous: With REST APIs being nothing more than data storage backends, we are able to reuse object relational mapping tools to access them.
 
@@ -84,8 +84,9 @@ Don't worry, if this is not the case: Luckily, we provide a few annotations for 
 Your API is allowed to respond with a handful of different HTTP status codes to
 be deemed a successful response.
 
+
 | Method    | "successful" status codes    |
-|-----------|------------------------------|
+| ----------- | ------------------------------ |
 | GET       | 200, 203, 206, 404           |
 | PUT/PATCH | 200, 202, 203, 204, 205, 404 |
 | POST      | 200, 201, 202, 203, 204, 205 |
@@ -122,21 +123,21 @@ class Product {
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
-    
+  
     /**
      * @ORM\Column(type="string", length=100)
      */
     private $name;
-    
+  
     public function getId() {
         return $this->id;
     }
-    
+  
     public function setName($name) {
         $this->name = $name;
         return $this;
     }
-    
+  
     public function getName() {
         return $this->name;
     }
@@ -153,7 +154,7 @@ By using this setting, the driver is performing a lot of magic under the hood:
 - It translates INSERT queries into POST requests to create new data
   - Urls have the following format: ```{apiHost}/{pathToApi}/{tableName}```
 - UPDATE queries will be turned into PUT requests:
-   - Urls have the following format: ```{apiHost}/{pathToApi}/{tableName}/{id}```
+  - Urls have the following format: ```{apiHost}/{pathToApi}/{tableName}/{id}```
 - The DELETE operation will remain:
   - Urls have the following format: ```{apiHost}/{pathToApi}/{tableName}/{id}```
 - SELECT queries become GET requests:
@@ -188,10 +189,10 @@ class UserController extends Controller {
         $entity->setName('Circle');
         $em->persist($entity);
         $em->flush();
-        
+    
         return new Response($entity->getId());
     }
-    
+  
     /**
      * Sends the following request to the API by default:
      * GET http://www.yourSite.com/api/products/1 HTTP/1.1
@@ -205,10 +206,10 @@ class UserController extends Controller {
     public function readAction($id = 1) {
         $em     = $this->getDoctrine()->getManager();
         $entity = $em->find('CircleBundle\Entity\Product', $id);
-        
+    
         return new Response($entity->getName());
     }
-    
+  
     /**
      * Sends the following request to the API:
      * GET http://www.yourSite.com/api/products HTTP/1.1
@@ -222,10 +223,10 @@ class UserController extends Controller {
     public function readAllAction() {
         $em       = $this->getDoctrine()->getManager();
         $entities = $em->getRepository('CircleBundle\Entity\Product')->findAll();
-        
+    
         return new Response($entities->first()->getName());
     }
-    
+  
     /**
      * After sending a GET request (readAction) it sends the following 
      * request to the API by default:
@@ -247,10 +248,10 @@ class UserController extends Controller {
         $entity = $em->find('CircleBundle\Entity\Product', $id);
         $entity->setName('myName');
         $em->flush();
-        
+    
         return new Response($entity->getName());
     }
-    
+  
     /**
      * After sending a GET request (readAction) it sends the following 
      * request to the API by default:
@@ -266,13 +267,14 @@ class UserController extends Controller {
         $entity = $em->find('CircleBundle\Entity\Product', $id);
         $em->remove($entity);
         $em->flush();
-        
+    
         return new Response();
     }
 }
 ```
 
 ## If your API doesn't follow our conventions
+
 Now it's time to introduce you to some annotations, which help you to configure your own routes. Be sure to use them only with ```Doctrine``` entities. All these annotations have the same structure so we will call them ```DataSource``` annotation:
 
 ```php
@@ -308,21 +310,21 @@ class Product {
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
-    
+  
     /**
      * @ORM\Column(type="string", length=100)
      */
     private $name;
-    
+  
     public function getId() {
         return $this->id;
     }
-    
+  
     public function setName($name) {
         $this->name = $name;
         return $this;
     }
-    
+  
     public function getName() {
         return $this->name;
     }
@@ -380,10 +382,10 @@ class UserController extends Controller {
         $entity->setName('Circle');
         $em->persist($entity);
         $em->flush();
-        
+    
         return new Response($entity->getId());
     }
-    
+  
     /**
      * Sends the following request to the API by default:
      * GET http://www.yourSite.com/api/products/findOne/1 HTTP/1.1
@@ -397,10 +399,10 @@ class UserController extends Controller {
     public function readAction($id = 1) {
         $em     = $this->getDoctrine()->getManager();
         $entity = $em->find('CircleBundle\Entity\Product', $id);
-        
+    
         return new Response($entity->getName());
     }
-    
+  
     /**
      * Sends the following request to the API:
      * GET http://www.yourSite.com/api/products/findAll HTTP/1.1
@@ -414,10 +416,10 @@ class UserController extends Controller {
     public function readAllAction() {
         $em       = $this->getDoctrine()->getManager();
         $entities = $em->getRepository('CircleBundle\Entity\Product')->findAll();
-        
+    
         return new Response($entities->first()->getName());
     }
-    
+  
     /**
      * After sending a GET request (readAction) it sends the following 
      * request to the API by default:
@@ -439,10 +441,10 @@ class UserController extends Controller {
         $entity = $em->find('CircleBundle\Entity\Product', $id);
         $entity->setName('myName');
         $em->flush();
-        
+    
         return new Response($entity->getName());
     }
-    
+  
     /**
      * After sending a GET request (readAction) it sends the following 
      * request to the API by default:
@@ -458,7 +460,7 @@ class UserController extends Controller {
         $entity = $em->find('CircleBundle\Entity\Product', $id);
         $em->remove($entity);
         $em->flush();
-        
+    
         return new Response();
     }
 }
@@ -505,12 +507,13 @@ doctrine:
 Need some more examples? Here they are:
 
 ## Persisting entities
+
 Imagine you have a REST API at http://www.your-url.com/api:
 
-| Route | Method | Description | Payload | Response | Success HTTP Code | Error HTTP Code |
-| ------------- |:-------------:| -----:|-----:|-----:|-----:|-----:|
-| /addresses | POST | persists addresses | UnregisteredAddress | RegisteredAddress | 200 | 400 |
 
+| Route      | Method |        Description |             Payload |          Response | Success HTTP Code | Error HTTP Code |
+| ------------ | :------: | -------------------: | --------------------: | ------------------: | ------------------: | ----------------: |
+| /addresses |  POST  | persists addresses | UnregisteredAddress | RegisteredAddress |               200 |             400 |
 
 ```c2hs
 typedef UnregisteredAddress {
@@ -557,35 +560,35 @@ class Address {
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
-    
+  
     /**
      * @ORM\Column(type="string")
      */
     private $street;
-    
+  
     /**
      * @ORM\Column(type="string")
      */
     private $city;
-    
+  
     public function setStreet($street) {
         $this->street = $street;
         return $this;
     }
-    
+  
     public function getStreet() {
         return $this->street;
     }
-    
+  
     public function setCity($city) {
         $this->city = $city;
         return $this;
     }
-    
+  
     public function getCity() {
         return $this->city;
     }
-    
+  
     public function getId() {
         return $this->id;
     }
@@ -607,10 +610,10 @@ class AddressController extends Controller {
     public function createAction($street, $city) {
         $em      = $this->getDoctrine()->getManager();
         $address = new CircleBundle\Address();
-        
+    
         $address->setStreet($street)->setCity($city);
         $em->persist($address);
-        
+    
         try {
             $em->flush();
             return new Response('successfully registered');
@@ -629,11 +632,12 @@ Let's extend the first example. Now we want to add a new entity type ```User``` 
 
 The REST API offers the following additional routes:
 
-| Route | Method | Description | Payload | Response |
-| ------------- |:-------------:| -----:|-----:|-----:|
-| /users | POST | persists a new user | UnregisteredUser | RegisteredUser |
-| /addresses | POST | persists a new address | UnregisteredAddress | RegisteredAddress |
-| /addresses/\<id\> | GET | returns one address | NULL | RegisteredAddress |
+
+| Route             | Method |            Description |             Payload |          Response |
+| ------------------- | :------: | -----------------------: | --------------------: | ------------------: |
+| /users            |  POST  |    persists a new user |    UnregisteredUser |    RegisteredUser |
+| /addresses        |  POST  | persists a new address | UnregisteredAddress | RegisteredAddress |
+| /addresses/\<id\> |  GET  |    returns one address |                NULL | RegisteredAddress |
 
 ```c2hs
 typedef UnregisteredUser {
@@ -669,49 +673,49 @@ class User {
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
-    
+  
     /**
      * @ORM\Column(type="string")
      */
     private $name;
-    
+  
     /**
      * @ORM\OneToOne(targetEntity="CircleBundle\Address", cascade={"persist, remove"})
      */
     private $address;
-    
+  
     /**
      * @ORM\Column(type="string")
      */
     private $password;
-    
+  
     public function setName($name) {
         $this->name = $name;
         return $this;
     }
-    
+  
     public function getName() {
         return $this->name;
     }
-    
+  
     public function setPassword($password) {
         $this->password = $password;
         return $this;
     }
-    
+  
     public function getPassword() {
         return $this->password;
     }
-    
+  
     public function getId() {
         return $this->id;
     }
-    
+  
     public function setAddress(Address $address) {
         $this->address = $address;
         return $this;
     }
-    
+  
     public function getAddress() {
         return $this->address;
     }
@@ -719,7 +723,6 @@ class User {
 ```
 
 The user has a relation to address. So let's have a look at what happens if we associate them:
-
 
 ```php
 <?php
@@ -735,14 +738,14 @@ class UserController extends Controller {
         $em      = $this->getDoctrine()->getManager();
         $address = $em->find("CircleBundle\Entity\Address", $addressId);
         $user    = new User();
-        
+    
         $user->setName($name)
             ->setPassword($password)
             ->setAddress($address);
-        
+    
         $em->persist($user);
         $em->flush();
-        
+    
         return new Response('successfully registered');
     }
 }
@@ -766,29 +769,29 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\HttpFoundation\Response;
 
 class UserController extends Controller {
-    
+  
     public function remove($id = 1) {
         $em = $this->getDoctrine()->getManager();
         $em->find('CircleBundle\Entity\User', $id);
         $em->remove($em);
         $em->flush();
-        
+    
         return new Response('successfully removed');
     }
 }
 ```
 
-
 For example, a DELETE request with the id ```1``` would trigger these requests:
+
 ```
 DELETE http://www.your-url.com/api/addresses/1 HTTP/1.1
 DELETE http://www.your-url.com/api/users/1 HTTP/1.1
 ```
 
-
 Great, isn't it?
 
 ## Using multiple Backends
+
 In this last example we split the user and the address routes into two different REST APIs.
 This means we need multiple managers which is explained in the Doctrine documentation:
 
@@ -824,15 +827,17 @@ doctrine:
 Now it's getting crazy: We will try to read data from two different APIs and persist them into a MySQL database.
 Imagine the user API with the following route:
 
-| Route | Method | Description | Payload | Response |
-| ------------- |:-------------:| -----:|-----:|-----:|
-| /users/\<id\> | GET | returns one user | NULL | RegisteredUser |
+
+| Route         | Method |      Description | Payload |       Response |
+| --------------- | :------: | -----------------: | --------: | ---------------: |
+| /users/\<id\> |  GET  | returns one user |    NULL | RegisteredUser |
 
 and the address API with this entry point:
 
-| Route | Method | Description | Payload | Response |
-| ------------- |:-------------:| -----:|-----:|-----:|
-| /addresses/\<id\> | GET | returns one address | NULL | RegisteredAddress |
+
+| Route             | Method |         Description | Payload |          Response |
+| ------------------- | :------: | --------------------: | --------: | ------------------: |
+| /addresses/\<id\> |  GET  | returns one address |    NULL | RegisteredAddress |
 
 We want to read a user from the user API and an address from the address API.
 After that we will associate and persist them in our MySQL database.
@@ -851,15 +856,15 @@ class UserController extends Controller {
         $emUsers       = $this->getDoctrine()->getManager('user_api');
         $emAddresses   = $this->getDoctrine()->getManager('address_api');
         $emPersistence = $this->getDoctrine()->getManager();
-        
+    
         $user    = $emUsers->find("CircleBundle\Entity\User", $userId);
         $address = $emAddresses->find("CircleBundle\Entity\Address", $addressId);
         $user->setAddress($address);
-        
+    
         $emPersistence->persist($address);
         $emPersistence->persist($user);
         $emPersistence->flush();
-        
+    
         return new Response('successfully persisted');
     }
 }
@@ -883,10 +888,12 @@ make test
 ```
 
 # Contributing
+
 If you want to contribute to this repository, please ensure ...
-  - to follow the existing coding style.
-  - to use the linting tools that are listed in the ```composer.json``` (which you get for free when using ```make```).
-  - to add and/or customize unit tests for any changed code.
-  - to reference the corresponding issue in your pull request with a small description of your changes.
+
+- to follow the existing coding style.
+- to use the linting tools that are listed in the ```composer.json``` (which you get for free when using ```make```).
+- to add and/or customize unit tests for any changed code.
+- to reference the corresponding issue in your pull request with a small description of your changes.
 
 All contributors are listed in the ```AUTHORS``` file, sorted by the time of their first contribution.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Motivation
 
 What does a black sheep and a white sheep have in common? They produce wool.<br />
-What does a big bus and a small bus have in common? They drive people ardoes a SQL database and a REST API have in common? They store data.<br />
+What does a big bus and a small bus have in common? They drive people around.<br />
+And what does a SQL database and a REST API have in common? They store data.<br />
 
 As blatantly obvious as this sounds the consequences are tremendous: With REST APIs being nothing more than data storage backends, we are able to reuse object relational mapping tools to access them.
 

--- a/Tests/Types/HttpQueryTest.php
+++ b/Tests/Types/HttpQueryTest.php
@@ -40,8 +40,8 @@ class HttpQueryTest extends \PHPUnit\Framework\TestCase {
      */
     public function create() {
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('SELECT name FROM products t0 WHERE t0.id=1 AND t0.value="testvalue" AND t0.name="testname"');
-        $expected = 'value=testvalue&name=testname';
+        $tokens   = $parser->parse('SELECT name FROM products t0 WHERE t0.id=1 AND t0.value="x=1" AND t0.name="test, name" OR (1=2 AND foo="bar")');
+        $expected = 'value=x=1&name=test, name|(1=2 & foo=bar)';
 
         $this->assertSame($expected, HttpQuery::create($tokens));
     }
@@ -73,7 +73,7 @@ class HttpQueryTest extends \PHPUnit\Framework\TestCase {
             'pagination_as_query' => true,
         ];
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('SELECT name FROM products WHERE foo="bar" LIMIT 5 OFFSET 10');
+        $tokens   = $parser->parse('SELECT name FROM products WHERE `foo`="bar" LIMIT 5 OFFSET 10');
         $expected = 'foo=bar&per_page=5&page=3';
 
         $this->assertSame($expected, HttpQuery::create($tokens, $options));
@@ -93,7 +93,7 @@ class HttpQueryTest extends \PHPUnit\Framework\TestCase {
             'page_param'          => 'newkey_page',
         ];
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('SELECT name FROM products WHERE foo="bar" LIMIT 5 OFFSET 10');
+        $tokens   = $parser->parse('SELECT `name` FROM products WHERE foo="bar" LIMIT 5 OFFSET 10');
         $expected = 'foo=bar&newkey_per_page=5&newkey_page=3';
 
         $this->assertSame($expected, HttpQuery::create($tokens, $options));

--- a/Tests/Types/IdentifierTest.php
+++ b/Tests/Types/IdentifierTest.php
@@ -32,73 +32,41 @@ use PHPSQLParser\PHPSQLParser;
 class IdentifierTest extends \PHPUnit\Framework\TestCase {
 
     /**
-     * @test
-     * @group  unit
-     * @covers ::create
+     * Provides Querystring + expected result for
      *
-     * @SuppressWarnings("PHPMD.StaticAccess")
+     * @see IdentifierTest::create()
+     *
+     * @return array
      */
-    public function create() {
-        $parser = new PHPSQLParser();
-        $tokens = $parser->parse('SELECT name FROM products WHERE id=1');
-
-        $this->assertSame('1', Identifier::create($tokens));
+    public function queryDataProvider() {
+        return [
+            ['SELECT name FROM products WHERE id="test"', 'test'],
+            ['SELECT name FROM products WHERE id="\\Foo\\bar"', '\\Foo\\bar'],
+            ['SELECT name FROM products WHERE id="id with space"', 'id with space'],
+            ['SELECT name FROM products WHERE id=\'test\'', 'test'],
+            ['SELECT name FROM products WHERE id=test', 'test'],
+            ['SELECT name FROM products WHERE id=1', '1'],
+            ['SELECT name FROM products WHERE name="test"', ''],
+        ];
     }
 
     /**
      * @test
-     * @group  unit
+     * @group        unit
      * @covers ::create
      *
-     * @SuppressWarnings("PHPMD.StaticAccess")
-     */
-    public function createWithStringId() {
-        $parser = new PHPSQLParser();
-        $tokens = $parser->parse('SELECT name FROM products WHERE id="test"');
-
-        $this->assertSame('test', Identifier::create($tokens));
-    }
-
-    /**
-     * @test
-     * @group  unit
-     * @covers ::create
+     * @dataProvider queryDataProvider
      *
      * @SuppressWarnings("PHPMD.StaticAccess")
-     */
-    public function createWithStringIdSingleQuotes() {
-        $parser = new PHPSQLParser();
-        $tokens = $parser->parse('SELECT name FROM products WHERE id=\'test\'');
-
-        $this->assertSame('test', Identifier::create($tokens));
-    }
-
-    /**
-     * @test
-     * @group  unit
-     * @covers ::create
      *
-     * @SuppressWarnings("PHPMD.StaticAccess")
+     * @param $query
+     * @param $expectedResult
      */
-    public function createWithStringIdNoQuotes() {
+    public function create($query, $expectedResult) {
         $parser = new PHPSQLParser();
-        $tokens = $parser->parse('SELECT name FROM products WHERE id=test');
+        $tokens = $parser->parse($query);
 
-        $this->assertSame('test', Identifier::create($tokens));
-    }
-
-    /**
-     * @test
-     * @group  unit
-     * @covers ::create
-     *
-     * @SuppressWarnings("PHPMD.StaticAccess")
-     */
-    public function createWithEmptyId() {
-        $parser = new PHPSQLParser();
-        $tokens = $parser->parse('SELECT name FROM products WHERE name="test"');
-
-        $this->assertSame('', Identifier::create($tokens));
+        $this->assertSame($expectedResult, Identifier::create($tokens));
     }
 
     /**

--- a/Tests/Types/InsertChangeSetTest.php
+++ b/Tests/Types/InsertChangeSetTest.php
@@ -41,7 +41,7 @@ class InsertChangeSetTest extends \PHPUnit\Framework\TestCase {
      */
     public function createWithRawValues() {
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('INSERT INTO products (name, value) VALUES (testname, testvalue)');
+        $tokens   = $parser->parse('INSERT INTO products (`name`, value) VALUES (testname, testvalue)');
         $expected = [
             'name'  => 'testname',
             'value' => 'testvalue',
@@ -58,12 +58,50 @@ class InsertChangeSetTest extends \PHPUnit\Framework\TestCase {
      *
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
-    public function createWithQuotedValues() {
+    public function createWithQuotedValuesWithWhiteSpaces() {
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('INSERT INTO products (name, value) VALUES ("testname", `testvalue`)');
+        $tokens   = $parser->parse("INSERT INTO products (name, value) VALUES (' testname\n', `testvalue`)");
         $expected = [
-            'name'  => 'testname',
+            'name'  => " testname\n",
             'value' => 'testvalue',
+        ];
+
+        $this->assertSame($expected, InsertChangeSet::create($tokens));
+    }
+
+    /**
+     * @test
+     * @group  unit
+     * @covers ::create
+     * @covers ::<private>
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function createWithQuotesInQuotedValues() {
+        $parser   = new PHPSQLParser();
+        $tokens   = $parser->parse('INSERT INTO products (name, value, foo) VALUES ("test,name", `testvalue`, \'b\'\'ar\')');
+        $expected = [
+            'name'  => 'test,name',
+            'value' => 'testvalue',
+            'foo'   => 'b\'ar',
+        ];
+
+        $this->assertSame($expected, InsertChangeSet::create($tokens));
+    }
+
+    /**
+     * @test
+     * @group  unit
+     * @covers ::create
+     * @covers ::<private>
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function createWithSurroundingQuotedValues() {
+        $parser   = new PHPSQLParser();
+        $tokens   = $parser->parse("INSERT INTO products (name) VALUES ('''test,name''')");
+        $expected = [
+            'name'  => '\'test,name\'',
         ];
 
         $this->assertSame($expected, InsertChangeSet::create($tokens));

--- a/Tests/Types/SelectAllResultTest.php
+++ b/Tests/Types/SelectAllResultTest.php
@@ -40,25 +40,29 @@ class SelectAllResultTest extends \PHPUnit\Framework\TestCase {
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
     public function create() {
-        $query  = 'SELECT name FROM products';
+        $query  = 'SELECT `name`, age FROM products';
         $parser = new PHPSQLParser();
         $tokens = $parser->parse($query);
 
         $content = [
             [
-                'name' => 'username'
+                'name' => 'username',
+                'age'  => 18,
             ],
             [
-                'name' => 'anotherUser'
+                'name' => 'anotherUser',
+                'age'  => 45,
             ],
         ];
 
         $expected = [
             [
-                'name' => 'username'
+                'name' => 'username',
+                'age'  => 18,
             ],
             [
-                'name' => 'anotherUser'
+                'name' => 'anotherUser',
+                'age'  => 45,
             ],
         ];
 

--- a/Tests/Types/SelectResultTest.php
+++ b/Tests/Types/SelectResultTest.php
@@ -64,25 +64,29 @@ class SelectResultTest extends \PHPUnit\Framework\TestCase {
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
     public function createAll() {
-        $query  = 'SELECT name FROM products';
+        $query  = 'SELECT `name`, age FROM products';
         $parser = new PHPSQLParser();
         $tokens = $parser->parse($query);
 
         $content = [
             [
-                'name' => 'username'
+                'name' => 'username',
+                'age'  => 18,
             ],
             [
-                'name' => 'anotherUser'
+                'name' => 'anotherUser',
+                'age'  => 45,
             ],
         ];
 
         $expected = [
             [
-                'name' => 'username'
+                'name' => 'username',
+                'age'  => 18,
             ],
             [
-                'name' => 'anotherUser'
+                'name' => 'anotherUser',
+                'age'  => 45,
             ],
         ];
 

--- a/Tests/Types/SelectSingleResultTest.php
+++ b/Tests/Types/SelectSingleResultTest.php
@@ -39,7 +39,7 @@ class SelectSingleResultTest extends \PHPUnit\Framework\TestCase {
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
     public function create() {
-        $query  = 'SELECT name FROM products WHERE id=1';
+        $query  = 'SELECT `name` FROM products WHERE id=1';
         $parser = new PHPSQLParser();
         $tokens = $parser->parse($query);
 

--- a/Tests/Types/UpdateChangeSetTest.php
+++ b/Tests/Types/UpdateChangeSetTest.php
@@ -40,9 +40,9 @@ class UpdateChangeSetTest extends \PHPUnit\Framework\TestCase {
      */
     public function create() {
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('UPDATE products set name="testname", value="testvalue" WHERE id=1');
+        $tokens   = $parser->parse('UPDATE products set `name`="test,name", value="testvalue" WHERE id=1');
         $expected = [
-            'name'  => 'testname',
+            'name'  => 'test,name',
             'value' => 'testvalue',
         ];
 
@@ -58,10 +58,10 @@ class UpdateChangeSetTest extends \PHPUnit\Framework\TestCase {
      */
     public function createRemovesWhitespace() {
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('UPDATE products set name = "testname", value = "testvalue" WHERE id = 1');
+        $tokens   = $parser->parse('UPDATE products set name = "test,name", `value` = "x=2" WHERE `id` = 1');
         $expected = [
-            'name'  => 'testname',
-            'value' => 'testvalue',
+            'name'  => 'test,name',
+            'value' => 'x=2',
         ];
 
         $this->assertSame($expected, UpdateChangeSet::create($tokens));

--- a/Tests/Types/ValueTest.php
+++ b/Tests/Types/ValueTest.php
@@ -40,11 +40,19 @@ class ValueTest extends \PHPUnit\Framework\TestCase {
     public function create() {
         $this->assertSame(1, Value::create('1'));
         $this->assertSame(1.01, Value::create('1.01'));
+        $this->assertSame('00', Value::create('00'));
         $this->assertSame('hello', Value::create('hello'));
         $this->assertSame('hello', Value::create('"hello"'));
         $this->assertSame('hello', Value::create('\'hello\''));
         $this->assertSame('hello', Value::create('`hello`'));
         $this->assertSame('\'hello"', Value::create('\'hello"'));
+        $this->assertSame('\'hel\'lo\'', Value::create('\'\'hel\'\'lo\'\''));
+
+        $this->assertSame("h\ne\nl\nl\no", Value::create("'h\ne\nl\nl\no'"));
+        $this->assertNotSame("h\ne\nl\nl\no", Value::create("'h\ne\nl\nl\no'\n"));
+
+        // any character outside of the quotes skips the "de-quoting"
+        $this->assertSame("'hello'\n", Value::create("'hello'\n"));
 
         $encoded = '{"test":true}';
 
@@ -56,5 +64,16 @@ class ValueTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame(null, Value::create('null'));
 
         $this->assertNotSame(null, Value::create('false'));
+    }
+
+    /**
+     * @test
+     * @group  unit
+     * @covers ::unquote
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function unquote() {
+        $this->assertSame('\'foo\'bar"', Value::unquote('\'foo\'\'bar"'));
     }
 }

--- a/Types/HttpQuery.php
+++ b/Types/HttpQuery.php
@@ -70,7 +70,7 @@ class HttpQuery {
 
         // Get WHERE conditions as string including table alias and primary key column if present
         $sqlWhereString = array_reduce($tokens['WHERE'], function($query, $token) use ($tableAlias) {
-            $baseExpr = str_replace(['"', '\''], '', str_replace('OR', '|', str_replace('AND', '&', $token['base_expr'])));
+            $baseExpr = str_replace(['"', '\'', '`'], '', str_replace('OR', '|', str_replace('AND', '&', $token['base_expr'])));
 
             return $query . ($token['expr_type'] == 'const' ? urlencode($baseExpr) : $baseExpr);
         });

--- a/Types/InsertChangeSet.php
+++ b/Types/InsertChangeSet.php
@@ -92,8 +92,10 @@ class InsertChangeSet {
         $isString          = false;
         $stringStartedWith = null;
 
-        while (($char = substr($values, $stringOffset++, 1)) !== false)
-        {
+        // must be -1 becuase string accessed as array has first `char` under "0"
+        $charactersLength = strlen($values) - 1;
+        for ($x = 0; $x <= $charactersLength; $x++) {
+            $char = $values[$x];
             // Handle the beginning, ending and escaping of characters
             if (static::isCharStringDelimiter($char, $stringStartedWith)) {
                 $stringStartedWith = null;

--- a/Types/InsertChangeSet.php
+++ b/Types/InsertChangeSet.php
@@ -76,7 +76,7 @@ class InsertChangeSet {
     }
 
     /**
-     * parses the values string into a an array that has the correct amount of values, compared with the column array.
+     * Parse the string values into an array that has the correct amount of values, compared with the column array
      *
      * @see isCharStringDelimiter for a list of valid string starting characters.
      * @see SqlQuery::quote() for the place where the automatic escape happens

--- a/Types/InsertChangeSet.php
+++ b/Types/InsertChangeSet.php
@@ -31,9 +31,11 @@ class InsertChangeSet {
      * into json
      *
      * @param  array $tokens
-     * @return string
+     *
+     * @return array|bool
      *
      * @SuppressWarnings("PHPMD.StaticAccess")
+     * @throws \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException
      */
     public static function create(array $tokens) {
         HashMap::assert($tokens, 'tokens');
@@ -66,21 +68,86 @@ class InsertChangeSet {
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
     public static function values(array $tokens) {
-        $values = explode(',', self::removeBrackets(self::removeSpacesBetweenComma(end($tokens['VALUES'])['base_expr'])));
+        $values = self::removeBrackets(end($tokens['VALUES'])['base_expr']);
 
         return array_map(function($value) {
             return Value::create($value);
-        }, $values);
+        }, static::parseValueStringToArray($values));
     }
 
     /**
-     * removes spaces between commas
+     * parses the values string into a an array that has the correct amount of values, compared with the column array.
      *
-     * @param  string $string
-     * @return string
+     * @see isCharStringDelimiter for a list of valid string starting characters.
+     * @see SqlQuery::quote() for the place where the automatic escape happens
+     *
+     * @param string $values
+     *
+     * @return array
      */
-    private static function removeSpacesBetweenComma($string) {
-        return str_replace(', ', ',', $string);
+    private static function parseValueStringToArray($values) {
+        $valueArray        = [''];
+        $currentValue      = 0;
+        $stringOffset      = 0;
+        $isString          = false;
+        $stringStartedWith = null;
+
+        while (($char = substr($values, $stringOffset++, 1)) !== false)
+        {
+            // Handle the beginning, ending and escaping of characters
+            if (static::isCharStringDelimiter($char, $stringStartedWith)) {
+                $stringStartedWith = null;
+
+                // Set the string that started this string sequence and also define it as the current escape character
+                if ($isString === false) {
+                    $stringStartedWith = $char;
+                }
+
+                // toggle string mode
+                $isString = !$isString;
+            }
+
+            // move the current value pointer to the next array key and create an empty string in it.
+            if (!$isString && $char === ',') {
+                $valueArray[++$currentValue] = '';
+                continue;
+            }
+
+            // skip whitespace characters when the current value is not flagged as a string
+            if (!$isString && preg_match('/\s/', $char)) {
+                continue;
+            }
+
+            // simply append the current character at the current array position
+            $valueArray[$currentValue] .= $char;
+        }
+
+        return $valueArray;
+    }
+
+    /**
+     * Checks if the character is on the list of starting characters
+     *
+     * @param string $char
+     *
+     * @return bool
+     */
+    private static function isStringStartingCharacter($char) {
+        return $char === '\'' || $char === '"' || $char === '`';
+    }
+
+    /**
+     * Checks if the character is on the list of starting characters and if it's identical to the starting character of
+     * the current string.
+     *
+     * @param string      $char
+     * @param string|null $startingChar
+     *
+     * @return bool
+     */
+    private static function isCharStringDelimiter($char, $startingChar) {
+        return static::isStringStartingCharacter($char)
+               && ($char === $startingChar || $startingChar === null);
     }
 
     /**

--- a/Types/SelectSingleResult.php
+++ b/Types/SelectSingleResult.php
@@ -41,8 +41,8 @@ class SelectSingleResult {
         $tableAlias = Table::alias($tokens);
 
         $attributeValueMap = array_map(function($token) use ($content, $tableAlias) {
-            $key   = empty($token['alias']['name']) ? $token['base_expr'] : $token['alias']['name'];
-            $value = $content[str_replace($tableAlias . '.', '', $token['base_expr'])];
+            $key   = str_replace('`', '', empty($token['alias']['name']) ? $token['base_expr'] : $token['alias']['name']);
+            $value = $content[str_replace([$tableAlias . '.', '`'], '', $token['base_expr'])];
             return [$key => $value];
         }, $tokens['SELECT']);
 

--- a/Types/SelectSingleResult.php
+++ b/Types/SelectSingleResult.php
@@ -42,7 +42,7 @@ class SelectSingleResult {
 
         $attributeValueMap = array_map(function($token) use ($content, $tableAlias) {
             $key   = str_replace('`', '', empty($token['alias']['name']) ? $token['base_expr'] : $token['alias']['name']);
-            $value = $content[str_replace([$tableAlias . '.', '`'], '', $token['base_expr'])];
+            $value = $content[str_replace([$tableAlias . '.', '`'], '', $token['base_expr'])] ?? null;
             return [$key => $value];
         }, $tokens['SELECT']);
 

--- a/Types/SqlQuery.php
+++ b/Types/SqlQuery.php
@@ -33,7 +33,7 @@ class SqlQuery {
     /**
      * replaces param placeholders with corresponding params
      *
-     * offset is moved to to the end of the newly added value so contained questionmarks are not interpreted as
+     * offset is moved to the end of the newly added value so contained question marks are not interpreted as
      * placeholders.
      *
      * @param  string $query

--- a/Types/SqlQuery.php
+++ b/Types/SqlQuery.php
@@ -18,6 +18,7 @@
 
 namespace Circle\DoctrineRestDriver\Types;
 
+use Circle\DoctrineRestDriver\Exceptions\QueryParameterMismatchException;
 use Circle\DoctrineRestDriver\Validation\Exceptions\NotNilException;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 
@@ -32,22 +33,44 @@ class SqlQuery {
     /**
      * replaces param placeholders with corresponding params
      *
+     * offset is moved to to the end of the newly added value so contained questionmarks are not interpreted as
+     * placeholders.
+     *
      * @param  string $query
      * @param  array  $params
+     *
      * @return string
      * @throws InvalidTypeException
      * @throws NotNilException
+     * @throws QueryParameterMismatchException
      *
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
     public static function setParams($query, array $params = []) {
         Str::assert($query, 'query');
 
-        return array_reduce($params, function($query, $param) {
+        $offset = 0;
+
+        $result = array_reduce($params, function($query, $param) use (&$offset) {
             $param = self::getStringRepresentation($param);
 
-            return strpos($query, '?') ? substr_replace($query, $param, strpos($query, '?'), strlen('?')) : $query;
+            $needle = '?';
+            $pos    = strpos($query, $needle, $offset);
+
+            if ($pos === false) {
+                throw new QueryParameterMismatchException($query, $needle);
+            }
+
+            $offset = $pos + strlen($param);
+
+            return $pos ? substr_replace($query, $param, $pos, strlen($needle)) : $query;
         }, $query);
+
+        if (strpos($result, '?', $offset) !== false) {
+            throw new QueryParameterMismatchException($query, '?');
+        }
+
+        return $result;
     }
 
     /**
@@ -59,14 +82,26 @@ class SqlQuery {
      */
     public static function getStringRepresentation($param)
     {
-        if (is_int($param) || is_float($param)) return $param;
-        if (is_numeric($param))                 return (float)$param;
-        if (is_string($param))                  return '\'' . $param . '\'';
-        if ($param === true)                    return 'true';
-        if ($param === false)                   return 'false';
-        if ($param === null)                    return 'null';
+        if (is_int($param) || is_float($param))                     return $param;
+        if (is_numeric($param) && (string)(float)$param === $param) return (float)$param;
+        if (is_numeric($param) && (string)(int)$param === $param)   return (int)$param;
+        if (is_string($param))                                      return '\'' . static::quote($param) . '\'';
+        if ($param === true)                                        return 'true';
+        if ($param === false)                                       return 'false';
+        if ($param === null)                                        return 'null';
 
         throw new \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException('string | int | float | bool | null', '$param', $param);
+    }
+
+    /**
+     * quotes single quotes sql-like with another single quote
+     *
+     * @param string $param
+     *
+     * @return string
+     */
+    public static function quote($param) {
+        return str_replace('\'', '\'\'', $param);
     }
 
     /**

--- a/Types/Table.php
+++ b/Types/Table.php
@@ -43,9 +43,9 @@ class Table {
         if (empty($tokens['FROM']) && empty($tokens['INSERT']) && empty($tokens['UPDATE'])) return Exceptions::InvalidTypeException('array', 'tokens', null);
 
         $operation = SqlOperation::create($tokens);
-        if ($operation === SqlOperations::INSERT) return $tokens['INSERT'][1]['no_quotes']['parts'][0];
-        if ($operation === SqlOperations::UPDATE) return $tokens['UPDATE'][0]['no_quotes']['parts'][0];
-        return $tokens['FROM'][0]['no_quotes']['parts'][0];
+        if ($operation === SqlOperations::INSERT) return $tokens['INSERT'][1]['no_quotes']['parts'][0] ?? null;
+        if ($operation === SqlOperations::UPDATE) return $tokens['UPDATE'][0]['no_quotes']['parts'][0] ?? null;
+        return $tokens['FROM'][0]['no_quotes']['parts'][0] ?? null;
     }
 
     /**
@@ -59,8 +59,8 @@ class Table {
 
         $operation = SqlOperation::create($tokens);
         if ($operation === SqlOperations::INSERT) return null;
-        if ($operation === SqlOperations::UPDATE) return $tokens['UPDATE'][0]['alias']['name'];
-        return $tokens['FROM'][0]['alias']['name'];
+        if ($operation === SqlOperations::UPDATE) return $tokens['UPDATE'][0]['alias']['name'] ?? null;
+        return $tokens['FROM'][0]['alias']['name'] ?? null;
     }
 
     /**

--- a/Types/Url.php
+++ b/Types/Url.php
@@ -47,11 +47,11 @@ class Url {
         Str::assert($apiUrl, 'apiUrl');
         MaybeString::assert($id, 'id');
 
-        $idPath = empty($id) ? '' : '/' . $id;
+        $idPath = empty($id) ? '' : '/' . rawurlencode($id);
 
         if (!self::is($route))               return $apiUrl . '/' . $route . $idPath;
         if (!preg_match('/\{id\}/', $route)) return $route . $idPath;
-        if (!empty($id))                     return str_replace('{id}', $id, $route);
+        if (!empty($id))                     return str_replace('{id}', rawurlencode($id), $route);
 
         return str_replace('/{id}', '', $route);
     }

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -45,10 +45,22 @@ class Value {
         if($value === 'false') return false;
         if($value === 'null')  return null;
 
-        $unquoted = preg_replace('/^(?|\"(.*)\"|\\\'(.*)\\\'|\`(.*)\`)$/', '$1', $value);
-        if (!is_numeric($unquoted))                   return $unquoted;
-        if ((string) intval($unquoted) === $unquoted) return intval($unquoted);
+        $unquoted = preg_replace('/^(?|\"(.*)\"|\\\'(.*)\\\'|\`(.*)\`)$/sD', '$1', $value);
+        if (!is_numeric($unquoted))                     return static::unquote($unquoted);
+        if ((string) intval($unquoted) === $unquoted)   return intval($unquoted);
+        if ((string) floatval($unquoted) === $unquoted) return floatval($unquoted);
 
-        return floatval($unquoted);
+        return $unquoted;
+    }
+
+    /**
+     * undoes the quoting
+     *
+     * @param string $param
+     *
+     * @return string
+     */
+    public static function unquote($param) {
+        return str_replace('\'\'', '\'', $param);
     }
 }


### PR DESCRIPTION
**Fixes**
- CRUD causing array access on type `bool`,
- `InsertChangesSet` (update action) causing: execution time exceeded,
- `SelectSingleResult` throwing undefined key,
- Callstack refers now to the `EntityManager` instead to `ObjectManager`,

**Other**
- applied old (NSC based) changes,